### PR TITLE
BALANCE: Пирратские корабли теперь недоступны раундстартом

### DIFF
--- a/code/modules/mob/dead/new_player/ship_select.dm
+++ b/code/modules/mob/dead/new_player/ship_select.dm
@@ -99,6 +99,9 @@
 			if(GLOB.real_names_joined.Find(name))
 				to_chat(spawnee, span_warning("Кто-то уже создал корабль с этим именем."))
 				return
+			if(template.category == "Pirates" && world.time < 3000) // 7200 мин
+				// Уводим логику в mod_celadon\ship_selection_rework\code\ship_select_enhanced.dm, но что, чёрт возьми, это такое? Мои глаза истекают кровью. Пожалуйста исправьте эту логику.
+				return
 			// [/CELADON-ADD]
 			if(SSovermap.ship_spawning)
 				to_chat(spawnee, span_danger("Корабль сейчас создаётся. Попробуйте снова через некоторое время."))

--- a/mod_celadon/ship_selection_rework/code/ship_select_enhanced.dm
+++ b/mod_celadon/ship_selection_rework/code/ship_select_enhanced.dm
@@ -116,6 +116,9 @@
 			if(GLOB.real_names_joined.Find(name))
 				to_chat(spawnee, span_warning("Someone has spawned with this name already."))
 				return
+			if(template.category == "Pirates" && world.time < 72000) // 72000 децисекунд => 2 часа.
+				to_chat(spawnee, span_warning("Отказано. Фракция пиратов открывается только после 2-ух часов игрового раунда."))
+				return
 			if(SSovermap.ship_spawning)
 				to_chat(spawnee, span_danger("A ship is currently spawning. Try again in a little while."))
 				return


### PR DESCRIPTION
## Описание / Что этот PR делает
Ранее корабли фракции "Пираты" были доступны на старте игры, что позволяло "душить" игроков на ранней стадии.
Теперь корабли будут доступны для покупки только после 2-ух часов раунда.

P.S. В процессе я обнаружил что логика покупки кораблей в целом работает неверно, это место молит произвести рефактор.
<img width="1716" height="546" alt="image" src="https://github.com/user-attachments/assets/81528e4d-67b1-44c2-b41e-a205f9eed24d" />

## Причина создания ПР / Почему это хорошо для игры
Согласно плану начинаем переводить пиратов в антагонистов.

## Демонстрация изменений / Тестирование

<img width="1375" height="736" alt="image" src="https://github.com/user-attachments/assets/ab45c097-ba16-4fcf-bc8b-8bcc01f876cd" />


## Список изменений

```yml
🆑
balance: Фракция пиратов теперь доступна после 2-ух часов игры.
/🆑
```
