### PR TITLE
HOTFIX: Manifest colors

### DIFF
--- a/mod_celadon/faction/code/faction.dm
+++ b/mod_celadon/faction/code/faction.dm
@@ -21,20 +21,26 @@
 /datum/faction/elysium
 	name = FACTION_ELYSIUM
 	prefixes = list("EUSM", "EUSQ", "EUSF", "EUSR", "ESV")
+	color = "#006400"
 
 /datum/faction/pirate
 	name = FACTION_PIRATES
 	prefixes = list("PIRATE", "RSV")
+	color = "#504c4c"
 
 /datum/faction/nanotrasen
 	name = FACTION_NANOTRASEN
 	prefixes = list("NTSV", "NTBSV", "NTASV", "NTSSV", "NTTSV", "NTMSV", "NTLSV", "NTDSV", "NTSPSV", "NTESV", "NTRSV")
+	color = "#32426b"
 
 /datum/faction/inteq
 	prefixes = list("IRMV", "IQMSSV", "BIQSV", "LIQSV", "SPIQSV")
+	color = "#E6B93C"
 
 /datum/faction/solgov
 	prefixes = list("SFSV", "BSFSV", "ASFSV", "SSFSV", "MDSFSV", "LSFSV", "MSFSV", "SPSFSV")
+	color = "#FFD700"
 
 /datum/faction/syndicate
 	prefixes = list("SEV", "SSV", "SMMV", "PCAC", "SSASV", "SSSV", "SOSSV", "TSSV", "SABSV", "BSSV", "ASSV", "MSSV", "LSSV", "DSSV", "RSSV",)
+	color = "#B22C20"

--- a/mod_celadon/faction/code/faction.dm
+++ b/mod_celadon/faction/code/faction.dm
@@ -31,7 +31,7 @@
 /datum/faction/nanotrasen
 	name = FACTION_NANOTRASEN
 	prefixes = list("NTSV", "NTBSV", "NTASV", "NTSSV", "NTTSV", "NTMSV", "NTLSV", "NTDSV", "NTSPSV", "NTESV", "NTRSV")
-	color = "#32426b"
+	color = "#283674"
 
 /datum/faction/inteq
 	prefixes = list("IRMV", "IQMSSV", "BIQSV", "LIQSV", "SPIQSV")
@@ -39,7 +39,7 @@
 
 /datum/faction/solgov
 	prefixes = list("SFSV", "BSFSV", "ASFSV", "SSFSV", "MDSFSV", "LSFSV", "MSFSV", "SPSFSV")
-	color = "#FFD700"
+	color = "#085a9d"
 
 /datum/faction/syndicate
 	prefixes = list("SEV", "SSV", "SMMV", "PCAC", "SSASV", "SSSV", "SOSSV", "TSSV", "SABSV", "BSSV", "ASSV", "MSSV", "LSSV", "DSSV", "RSSV",)

--- a/mod_celadon/faction/code/faction.dm
+++ b/mod_celadon/faction/code/faction.dm
@@ -31,15 +31,15 @@
 /datum/faction/nanotrasen
 	name = FACTION_NANOTRASEN
 	prefixes = list("NTSV", "NTBSV", "NTASV", "NTSSV", "NTTSV", "NTMSV", "NTLSV", "NTDSV", "NTSPSV", "NTESV", "NTRSV")
-	color = "#283674"
+	color = "#2945c5"
 
 /datum/faction/inteq
 	prefixes = list("IRMV", "IQMSSV", "BIQSV", "LIQSV", "SPIQSV")
-	color = "#E6B93C"
+	color = "#914E01"
 
 /datum/faction/solgov
 	prefixes = list("SFSV", "BSFSV", "ASFSV", "SSFSV", "MDSFSV", "LSFSV", "MSFSV", "SPSFSV")
-	color = "#085a9d"
+	color = "#721ed3"
 
 /datum/faction/syndicate
 	prefixes = list("SEV", "SSV", "SMMV", "PCAC", "SSASV", "SSSV", "SOSSV", "TSSV", "SABSV", "BSSV", "ASSV", "MSSV", "LSSV", "DSSV", "RSSV",)


### PR DESCRIPTION
## Описание / Что этот PR делает
В манифесте у фракций теперь будет правильный цвет. Не знаю почему его не задавали раньше.

## Причина создания ПР / Почему это хорошо для игры
Чинит + красивше

## Демонстрация изменений / Тестирование
<img width="354" height="545" alt="image" src="https://github.com/user-attachments/assets/9bbf7425-2f3a-403e-9fa5-011b6b437b9e" />

## Список изменений

```yml
🆑
fix: Manifest Colors
/🆑
```
