### PR TITLE
[FIX] Исправление интерфейса проводов

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -256,7 +256,7 @@
 	else if(user.is_holding_item_of_type(/obj/item/multitool/abductor) || user.is_holding_item_of_type(/obj/item/debug/omnitool)) // [CELADON-EDIT] - OLD CODE: else if(user.is_holding_item_of_type(/obj/item/multitool/abductor))
 		reveal_wires = TRUE
 
-	// [CELADON-ADD] 
+	// [CELADON-ADD]
 	// Same for anyone with engineering scanner goggles and multitool/wirecutter/Jaws of live in hands
 	else if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -270,9 +270,10 @@
 				has_valid_tool = TRUE
 
 		if(has_valid_tool && H.glasses)
-			var/obj/item/clothing/glasses/G = H.glasses
-			if(G.vars["mode"] && G.vars["mode"] == "t-ray")
-				reveal_wires = TRUE
+			if(istype(H.glasses, /obj/item/clothing/glasses/meson/engine))
+				var/obj/item/clothing/glasses/meson/engine/G = H.glasses
+				if(G.mode == "t-ray")
+					reveal_wires = TRUE
 	// [/CELADON-ADD]
 
 	// Station blueprints do that too, but only if the wires are not randomized.


### PR DESCRIPTION
## Описание / Что этот PR делает
Чиним момент когда при одевании различных очков, интерфейс проводов не появлялся:
<img width="466" height="230" alt="image" src="https://github.com/user-attachments/assets/dbc863d5-44c1-47b2-a24f-299abd6f691f" />
<img width="1000" height="233" alt="image" src="https://github.com/user-attachments/assets/3a0f12ed-4e78-49fd-8508-5b1c54b9dec3" />


Теперь все на более безопасных istype сделано и больше не рантаймит из-за других очков. (Проще говоря, все работает)
## Причина создания ПР / Почему это хорошо для игры
Фикс прикола с проводами

## Демонстрация изменений / Тестирование
(Файл с видео слишком большой, так что open youtube)

https://youtu.be/LGz1gG-DDOg

## Список изменений

```yml
🆑Azzy.Dreemurr
fix: Интерфейс проводов у шлюзов, вендоматов и т.д. вновь появляется корректно
/🆑
```
