### PR TITLE
TWEAK: Временно отключаем возможность столкновения кораблей

### DIFF
--- a/code/controllers/subsystem/overmap_move.dm
+++ b/code/controllers/subsystem/overmap_move.dm
@@ -76,9 +76,10 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 				if(world.time - A.last_collision_alert >= 20)
 					A.last_collision_alert = world.time
 					while (arpdequeue_pointer++ < A.helms.len)
-						var/obj/machinery/computer/helm/a = A.helms[arpdequeue_pointer]
-						a.say("Collision impact with vessel \"[B.name]\".")
-						playsound(a, 'sound/machines/engine_alert2.ogg', 50, FALSE)
+						// Отключаем оповещение о возможном столкновении.  Collision OFF
+						// var/obj/machinery/computer/helm/a = A.helms[arpdequeue_pointer]
+						// a.say("Collision impact with vessel \"[B.name]\".")
+						// playsound(a, 'sound/machines/engine_alert2.ogg', 50, FALSE)
 				var/opposite_x = sin(SIMPLIFY_DEGREES(bearing+180))*(B.shuttle_port.turf_count/A.shuttle_port.turf_count)*max(0.002, abs(B.speed_x))
 				var/opposite_y = cos(SIMPLIFY_DEGREES(bearing+180))*(B.shuttle_port.turf_count/A.shuttle_port.turf_count)*max(0.002, abs(B.speed_y))
 				var/alt_opposite_x = sin(SIMPLIFY_DEGREES(bearing))*(B.shuttle_port.turf_count/A.shuttle_port.turf_count)*max(0.002, abs(B.speed_x))
@@ -91,8 +92,9 @@ TIMER_SUBSYSTEM_DEF(overmap_movement)
 					B.adjust_speed(-B.speed_x/2 + alt_opposite_x, -B.speed_y/2 + alt_opposite_y)
 				else
 					B.vector_to_add = list("x" = -B.speed_x/2 + alt_opposite_x, "y" = -B.speed_y/2 + alt_opposite_y)
-				spawn_meteors_alt(round(60 SECONDS * MAGNITUDE(relative_motion_x, relative_motion_y))+1, list(/obj/effect/meteor/invisible), A.shuttle_port.get_virtual_level(), A.shuttle_port, angle2dir_cardinal(SIMPLIFY_DEGREES((bearing-A.bow_heading+90))))
-				spawn_meteors_alt(round(60 SECONDS * MAGNITUDE(relative_motion_x, relative_motion_y))+1, list(/obj/effect/meteor/invisible), B.shuttle_port.get_virtual_level(), B.shuttle_port, angle2dir_cardinal(SIMPLIFY_DEGREES((bearing-A.bow_heading+270))))
+				// Отключаем повреждения (таран) при столкновении.  Collision OFF
+				// spawn_meteors_alt(round(60 SECONDS * MAGNITUDE(relative_motion_x, relative_motion_y))+1, list(/obj/effect/meteor/invisible), A.shuttle_port.get_virtual_level(), A.shuttle_port, angle2dir_cardinal(SIMPLIFY_DEGREES((bearing-A.bow_heading+90))))
+				// spawn_meteors_alt(round(60 SECONDS * MAGNITUDE(relative_motion_x, relative_motion_y))+1, list(/obj/effect/meteor/invisible), B.shuttle_port.get_virtual_level(), B.shuttle_port, angle2dir_cardinal(SIMPLIFY_DEGREES((bearing-A.bow_heading+270))))
 
 	return list("cpa" = round(cpa), "tcpa" = round(tcpa/10), "brg" = round(SIMPLIFY_DEGREES(bearing-A.bow_heading)))
 


### PR DESCRIPTION
## Описание / Что этот PR делает
К сожалению сейчас таран используется только в качестве гриффа, да и правилами это запрещено, что делает существование тарана хоть и логичным, но абсолютно бессмысленным с положительной точки зрения.

На будущее рекомендуется привести в модульность механики, что были созданы в https://github.com/CeladonSS13/Shiptest/commit/33fbb342adf9f579dc21e7c508c97b602887389d

## Причина создания ПР / Почему это хорошо для игры
На данный момент не имеется корабельного вооружения, а также отсутствует возможность использовать барьер, чтобы защитить корабль от полноценного вывода своей команды из игры. 

## Демонстрация изменений / Тестирование
Оповещение о возможном столкновении остаётся.
Предупреждение будет о возможном столкновении, но взрыва не последует.

<img width="1200" height="628" alt="image" src="https://github.com/user-attachments/assets/46ca41f2-084e-4a14-937d-0c4c411af4de" />

## Список изменений

```yml
🆑
tweak: Временно отключена возможность столкновения кораблей.
/🆑
```
