### PR TITLE
FIX: Исправление работы печки на аванпосту

### DIFF
--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -2814,6 +2814,11 @@
 "bDB" = (
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/machinery/light/directional/north,
+/obj/machinery/computer/processing_unit_console/directional/east{
+	machinedir = 8;
+	output_dir = 1;
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
 "bDR" = (
@@ -18974,9 +18979,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/industrial/warning,
-/obj/machinery/computer/processing_unit_console/directional/east{
-	machinedir = 1
-	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
 "khD" = (
@@ -27256,6 +27258,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
+"oJt" = (
+/turf/open/space/basic,
+/area/outpost/external)
 "oJu" = (
 /obj/structure/spider/stickyweb{
 	color = "#808080"
@@ -27986,6 +27991,11 @@
 /obj/effect/turf_decal/industrial/hatch/yellow,
 /obj/structure/sign/poster/nanotrasen/work_for_a_future{
 	pixel_x = 32
+	},
+/obj/machinery/computer/processing_unit_console/directional/east{
+	machinedir = 8;
+	output_dir = 1;
+	pixel_y = 30
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
@@ -35355,9 +35365,6 @@
 	},
 /obj/effect/turf_decal/industrial/warning{
 	dir = 1
-	},
-/obj/machinery/computer/processing_unit_console/directional/east{
-	machinedir = 1
 	},
 /turf/open/floor/plasteel/patterned,
 /area/outpost/cargo/smeltery)
@@ -73414,7 +73421,7 @@ hQU
 rgY
 hQU
 hQU
-rgY
+oJt
 rgY
 hQU
 hQU

--- a/_maps/_mod_celadon/outpost/elysium_ice.dmm
+++ b/_maps/_mod_celadon/outpost/elysium_ice.dmm
@@ -27258,9 +27258,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/outpost/cargo)
-"oJt" = (
-/turf/open/space/basic,
-/area/outpost/external)
 "oJu" = (
 /obj/structure/spider/stickyweb{
 	color = "#808080"
@@ -73421,7 +73418,7 @@ hQU
 rgY
 hQU
 hQU
-oJt
+hQU
 rgY
 hQU
 hQU


### PR DESCRIPTION
## Описание / Что этот PR делает
Теперь печка на аванпосту Elysium Ice работает корректно.

## Причина создания ПР / Почему это хорошо для игры
Ранее консоль не работала из-за того, что не инициализировалась (связывалась) рядом по тайлу с печкой.

Дополнение к: https://github.com/CeladonSS13/Shiptest/pull/2938
Причина: https://github.com/CeladonSS13/Shiptest/issues/2934

## Демонстрация изменений / Тестирование
Ресурсы плавятся, панель открывается, ресурсы выдаются.

<img width="708" height="511" alt="image" src="https://github.com/user-attachments/assets/3f5a6823-c568-4418-9785-5cf5c124db26" />

## Список изменений

```yml
🆑
fix: Исправление печки на аванпосту.
/🆑
```
