### PR TITLE
ADD: Outpost Names

### DIFF
--- a/mod_celadon/maps/code/outpost.dm
+++ b/mod_celadon/maps/code/outpost.dm
@@ -6,6 +6,8 @@
 
 /datum/map_template/outpost/elysium_asteroid
 	name = "elysium_asteroid"
+	outpost_name = "Fada La Nihayiyun"
+	outpost_administrator = "Elysian Administration"
 
 /datum/map_template/outpost/hangar/elysium_asteroid_20x20
 	name = "hangar/elysium_asteroid_20x20"
@@ -49,6 +51,8 @@
 */
 /datum/map_template/outpost/elysium_ice
 	name = "elysium_ice"
+	outpost_name = "Easifat Thaljia"
+	outpost_administrator = "Elysian Administration"
 
 /datum/map_template/outpost/hangar/elysium_ice_20x20
 	name = "hangar/elysium_ice_20x20"


### PR DESCRIPTION
## Описание / Что этот PR делает
Дает обоим текущим аванпостам название и администратора

## Причина создания ПР / Почему это хорошо для игры
У нас не будет появляться дебаговый FALLBACK OUTPOST и FALLBACK ADMINISTRATOR в игре

## Демонстрация изменений / Тестирование
<img width="201" height="30" alt="image" src="https://github.com/user-attachments/assets/b10a4421-4774-41e3-bb47-f04451735aad" />

## Список изменений

```yml
🆑
add: Outpost names
/🆑
```
